### PR TITLE
fix: update pki-issuer image to v0.1.3 tag

### DIFF
--- a/build/install.yaml
+++ b/build/install.yaml
@@ -588,7 +588,7 @@ spec:
         - --health-probe-bind-address=:8081
         command:
         - /manager
-        image: docker.io/infisical/pki-issuer:v0.1.1-3-gc2030ef
+        image: docker.io/infisical/pki-issuer:v0.1.3
         livenessProbe:
           httpGet:
             path: /healthz


### PR DESCRIPTION
The deployment for `infisical-issuer-controller-manager` was failing due to an inability to pull the Docker image `docker.io/infisical/pki-issuer:v0.1.1-3-gc2030ef`. This specific image tag was not found in the Docker Hub registry, likely because it was a development or temporary tag that is no longer available.

This commit updates the image tag to `v0.1.3`, which is the latest stable release found on the official Infisical PKI Issuer GitHub repository releases page and confirmed to exist on Docker Hub.

This change resolves the image pull error and allows the controller manager to deploy successfully, for me, and anyone else who tries!  Presumably it hasn't worked for a while - for anyone!