### PR TITLE
improvement(helm): switch helm chart release to OCI push

### DIFF
--- a/.github/workflows/release-helm-chart.yaml
+++ b/.github/workflows/release-helm-chart.yaml
@@ -47,13 +47,8 @@ jobs:
         with:
           version: v3.10.0
 
-      - name: Install python
-        uses: actions/setup-python@v4
-
-      - name: Install Cloudsmith CLI
-        run: pip install --upgrade cloudsmith-cli
-
       - name: Build and push helm package to CloudSmith
         run: cd helm-charts && sh upload-infisical-pki-issuer-chart.sh
         env:
           CLOUDSMITH_API_KEY: ${{ secrets.CLOUDSMITH_API_KEY }}
+          CLOUDSMITH_USERNAME: ${{ secrets.CLOUDSMITH_USERNAME }}

--- a/.github/workflows/release-helm-chart.yaml
+++ b/.github/workflows/release-helm-chart.yaml
@@ -24,6 +24,8 @@ jobs:
 
       - name: Set up chart-testing
         uses: helm/chart-testing-action@v2.7.0
+        with:
+          yamale_version: "6.0.0"
 
       - name: Run chart-testing (lint)
         run: ct lint --config ct.yaml --charts helm-charts/infisical-pki-issuer

--- a/.github/workflows/run-helm-chart-tests.yaml
+++ b/.github/workflows/run-helm-chart-tests.yaml
@@ -27,6 +27,8 @@ jobs:
 
       - name: Set up chart-testing
         uses: helm/chart-testing-action@v2.7.0
+        with:
+          yamale_version: "6.0.0"
 
       - name: Run chart-testing (lint)
         run: ct lint --config ct.yaml --charts helm-charts/infisical-pki-issuer

--- a/helm-charts/infisical-pki-issuer/Chart.yaml
+++ b/helm-charts/infisical-pki-issuer/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.1.1
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/helm-charts/infisical-pki-issuer/Chart.yaml
+++ b/helm-charts/infisical-pki-issuer/Chart.yaml
@@ -18,4 +18,4 @@ version: 0.1.1
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.1.0"
+appVersion: "0.1.1"

--- a/helm-charts/upload-infisical-pki-issuer-chart.sh
+++ b/helm-charts/upload-infisical-pki-issuer-chart.sh
@@ -1,8 +1,23 @@
+#!/usr/bin/env sh
+set -e
+
+if [ -z "$CLOUDSMITH_API_KEY" ] || [ -z "$CLOUDSMITH_USERNAME" ]; then
+    echo "Error: CLOUDSMITH_API_KEY and CLOUDSMITH_USERNAME environment variables must be set."
+    exit 1
+fi
+
 cd infisical-pki-issuer
 helm dependency update
 helm package .
+
+echo "$CLOUDSMITH_API_KEY" | helm registry login helm.oci.cloudsmith.io \
+    --username "$CLOUDSMITH_USERNAME" \
+    --password-stdin
+
 for i in *.tgz; do
     [ -f "$i" ] || break
-    cloudsmith push helm --republish infisical/helm-charts "$i"
+    helm push "$i" oci://helm.oci.cloudsmith.io/infisical/helm-charts
 done
+
+helm registry logout helm.oci.cloudsmith.io
 cd ..


### PR DESCRIPTION
The Helm chart release workflow used the Cloudsmith CLI (`cloudsmith push helm`) to publish charts. Cloudsmith also exposes an OCI registry, and pushing via OCI produces the same traditional Helm artifacts (e.g. `index.yaml`, `.tgz` files) while using the standard `helm push` flow.

This change switches the Helm release pipeline to OCI push only, matching the approach used in [infisical-agent-injector](https://github.com/Infisical/infisical-agent-injector/blob/main/upload-to-cloudsmith.sh).

I also updated the test and release workflow to match the versions used by other helm release workflows, like the operator one:

https://github.com/Infisical/kubernetes-operator/blob/main/.github/workflows/run-helm-chart-test

https://github.com/Infisical/kubernetes-operator/blob/main/.github/workflows/release-k8-operator-helm.ymls-secret-operator.yml